### PR TITLE
Fix burn_after_reading feature, along with zerobin.py

### DIFF
--- a/zerobin.py
+++ b/zerobin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from zerobin.routes import main
+from zerobin.cmd import main
 
 main()

--- a/zerobin/paste.py
+++ b/zerobin/paste.py
@@ -172,7 +172,6 @@ class Paste(object):
         # deleting the paste
         if "burn_after_reading" == self.expiration:
             expiration = self.expiration + '#%s' % datetime.now()  # TODO: use UTC dates
-            expiration = self.expiration
         else:
             expiration = as_unicode(self.expiration)
 


### PR DESCRIPTION
As promised, a quick fix to solve #81 and #90 

It also repairs zerobin.py