### PR TITLE
Support optional GCP API key for URL shortener

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description="An client side encrypted pastebin",
     long_description=open('README.rst').read(),
     install_requires=[
-        'cherrypy',
+        'cherrypy>=3.8.0,<9.0.0',
         'bottle',
         'clize',
         'lockfile',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     install_requires=[
         'cherrypy>=3.8.0,<9.0.0',
         'bottle',
+        'funcsigs',
         'clize',
         'lockfile',
     ],

--- a/zerobin/default_settings.py
+++ b/zerobin/default_settings.py
@@ -76,3 +76,7 @@ MAX_SIZE = 1024 * 500
 # total number of unique pastes can be calculated as 2^(6*PASTE_ID_LENGTH)
 # for PASTE_ID_LENGTH=8, for example, it's 2^(6*8) = 281 474 976 710 656
 PASTE_ID_LENGTH = 8
+
+# Optional Google API key to use to call URL shortener API. If left `None`,
+# URL shortening will be disabled.
+SHORTENER_API_KEY = None

--- a/zerobin/routes.py
+++ b/zerobin/routes.py
@@ -174,4 +174,7 @@ def get_app(debug=None, settings_file='',
     if settings.DEBUG:
         bottle.debug(True)
 
+    if settings.SHORTENER_API_KEY is None:
+        raise SettingsValidationError('SHORTENER_API_KEY must be set')
+
     return settings, app

--- a/zerobin/routes.py
+++ b/zerobin/routes.py
@@ -174,7 +174,4 @@ def get_app(debug=None, settings_file='',
     if settings.DEBUG:
         bottle.debug(True)
 
-    if settings.SHORTENER_API_KEY is None:
-        raise SettingsValidationError('SHORTENER_API_KEY must be set')
-
     return settings, app

--- a/zerobin/static/js/behavior.js
+++ b/zerobin/static/js/behavior.js
@@ -206,7 +206,7 @@
     /** Get a tinyurl using JSONP */
     getTinyURL: function(longURL, success) {
         $.ajax({
-  		  url: 'https://www.googleapis.com/urlshortener/v1/url',
+  		  url: 'https://www.googleapis.com/urlshortener/v1/url?key=' + zerobin.shortener_api_key,
   		  type: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({

--- a/zerobin/views/base.tpl
+++ b/zerobin/views/base.tpl
@@ -36,7 +36,7 @@
 
     <script type="text/javascript">
       zerobin.max_size = {{ settings.MAX_SIZE }};
-      zerobin.shortener_api_key = {{ settings.SHORTENER_API_KEY }};
+      zerobin.shortener_api_key = "{{ settings.SHORTENER_API_KEY }}";
     </script>
 
   </head>

--- a/zerobin/views/base.tpl
+++ b/zerobin/views/base.tpl
@@ -36,6 +36,7 @@
 
     <script type="text/javascript">
       zerobin.max_size = {{ settings.MAX_SIZE }};
+      zerobin.shortener_api_key = {{ settings.SHORTENER_API_KEY }};
     </script>
 
   </head>

--- a/zerobin/views/base.tpl
+++ b/zerobin/views/base.tpl
@@ -38,7 +38,7 @@
       zerobin.max_size = {{ settings.MAX_SIZE }};
       %if settings.SHORTENER_API_KEY:
         zerobin.shortener_api_key = "{{ settings.SHORTENER_API_KEY }}";
-      %endif
+      %end
     </script>
 
   </head>

--- a/zerobin/views/base.tpl
+++ b/zerobin/views/base.tpl
@@ -36,7 +36,9 @@
 
     <script type="text/javascript">
       zerobin.max_size = {{ settings.MAX_SIZE }};
-      zerobin.shortener_api_key = "{{ settings.SHORTENER_API_KEY }}";
+      %if settings.SHORTENER_API_KEY:
+        zerobin.shortener_api_key = "{{ settings.SHORTENER_API_KEY }}";
+      %endif
     </script>
 
   </head>

--- a/zerobin/views/paste.tpl
+++ b/zerobin/views/paste.tpl
@@ -23,7 +23,9 @@
 <form action="/" method="get" accept-charset="utf-8">
 <p class="lnk-option">
   <a id="clip-button" href="#">Copy To Clipboard</a> |
+%if settings.SHORTENER_API_KEY:
   <a id="short-url" href="#">Get short url</a> |
+%endif
   <a id="email-link" href="#">Email this</a>
 
   <span class="paste-option btn-group top">

--- a/zerobin/views/paste.tpl
+++ b/zerobin/views/paste.tpl
@@ -25,7 +25,7 @@
   <a id="clip-button" href="#">Copy To Clipboard</a> |
 %if settings.SHORTENER_API_KEY:
   <a id="short-url" href="#">Get short url</a> |
-%endif
+%end
   <a id="email-link" href="#">Email this</a>
 
   <span class="paste-option btn-group top">


### PR DESCRIPTION
Because the shortener API call requires a key, provide a setting to optionally pass this API key to the client-side javascript call.